### PR TITLE
Fixed getLastfmUser to not return 1 for no user......

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ircconfig.ini
+*.ini
 *.swp
 

--- a/modules/lastfm.php
+++ b/modules/lastfm.php
@@ -77,20 +77,29 @@ function deleteLastfmUser() {
 	send_msg($channel,$message);
 }
 
+/**
+ * Retrieve a Last.fm user per nickname. This was in the version I had on my
+ * server - I've switched it with the original one as that returns 1 a lot...
+ *
+ * @param string $nick - nickname to search
+ * @global string $channel
+ * @return mixed
+ */
 function getLastfmUser($nick) {
 	global $channel;
 
-	$file 		= './data/lastfm_data.json';
-	$fc 		= file_get_contents($file);
-	$users 		= json_decode($fc, true);
-	$message 	= true;
-	foreach ($users['users'] as $key => $lastfm) {
-		if (preg_match('/' .$nick . '/i', $key)) {
-			$message = $lastfm['lastfmuser'];
-		}
-	}
-	return $message;
-}
+	$file = "./data/lastfm_data.json";
+	$fc = file_get_contents($file);
+	$users = json_decode($fc, true);
+
+	foreach ($users["users"] as $key => $lastfm) {
+		if (preg_match("/{$nick}/i", $key)) {
+			return $lastfm["lastfmuser"];
+		} // if
+	} // foreach
+
+	return;
+} // getLastfmUser
 
 function getLastfmData($method, $parameters) {
 	global $loaded_modules, $channel;


### PR DESCRIPTION
Corrects '"1" last listened to...' issue for users with no username set! As noted, I think this was one of kwamaking or SBG's changes that was never merged.